### PR TITLE
change h2 to h1

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,8 +81,8 @@
        lg:mx-8  
       ">
 
-        <h2 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Simple, Effective Software QA Services for Your Business
-        </h2>
+        <h1 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Simple, Effective Software QA Services for Your Business
+        </h1>
         <h2 class="text-2xl font-bold tracking-tight text-gray-900 sm:text-2xl py-6">Flawless performance- one fixed price</h2>
         <p class="mt-2 text-lg leading-8 text-gray-600">
           Is malfunctioning software damaging your reputation and causing customer churn? <b>Effective QA</b> offers a software quality assurance solution. 


### PR DESCRIPTION
In order to be compliant with SEO rules, a H1 should exist in the page.